### PR TITLE
#40: Update to `exaerror` 2.0.0

### DIFF
--- a/src/exasolvs/AbstractVirtualSchemaAdapter.lua
+++ b/src/exasolvs/AbstractVirtualSchemaAdapter.lua
@@ -1,4 +1,4 @@
-local exaerror = require("exaerror")
+local ExaError = require("ExaError")
 
 --- This class implements an abstract base adapter with common behavior for some of the request callback functions.
 -- @classmod AbstractVirtualSchemaAdapter
@@ -15,7 +15,7 @@ function AbstractVirtualSchemaAdapter:_init()
 end
 
 local function raise_abstract_method_call_error(method_name)
-    exaerror.create("E-VSCL-8", "Attempted to call the abstract method AbstractVirtualSchemaAdapter:{{method|u}}.",
+    ExaError:new("E-VSCL-8", "Attempted to call the abstract method AbstractVirtualSchemaAdapter:{{method|u}}.",
             {method = {value = method_name, description = "abstract method that was called"}}
     ):add_ticket_mitigation():raise()
 end

--- a/src/exasolvs/AdapterProperties.lua
+++ b/src/exasolvs/AdapterProperties.lua
@@ -1,5 +1,5 @@
 local text = require("text")
-local exaerror = require("exaerror")
+local ExaError = require("ExaError")
 
 --- This class abstracts access to the user-defined properties of the Virtual Schema.
 -- @classmod AdapterProperties
@@ -57,7 +57,7 @@ function AdapterProperties:_validate_debug_address()
     if self:has_value(DEBUG_ADDRESS_PROPERTY) then
         local address = self:get(DEBUG_ADDRESS_PROPERTY)
         if not string.match(address, "^.-:[0-9]+$") then
-            exaerror.create("F-VSCL-PROP-3", "Expected log address in " .. DEBUG_ADDRESS_PROPERTY
+            ExaError:new("F-VSCL-PROP-3", "Expected log address in " .. DEBUG_ADDRESS_PROPERTY
                     .. " to look like '<ip>|<host>[:<port>]', but got {{address}} instead"
                     , {address = address})
                     :add_mitigations("Provide an valid IP address or host name")
@@ -81,7 +81,7 @@ function AdapterProperties:_validate_log_level()
             end
         end
         if not found then
-            exaerror.create("F-VSCL-PROP-2", "Unknown log level {{level}} in " .. LOG_LEVEL_PROPERTY .. " property",
+            ExaError:new("F-VSCL-PROP-2", "Unknown log level {{level}} in " .. LOG_LEVEL_PROPERTY .. " property",
                     {level = level})
                     :add_mitigations("Pick one of: " .. table.concat(allowed_levels, ", "))
                     :raise()
@@ -93,7 +93,7 @@ function AdapterProperties:_validate_excluded_capabilities()
     if self:has_value(EXCLUDED_CAPABILITIES_PROPERTY) then
         local value = self:get(EXCLUDED_CAPABILITIES_PROPERTY)
         if not string.match(value, "^[ A-Za-z0-9_,]*$") then
-            exaerror.create("F-VSCL-PROP-1", "Invalid character(s) in " .. EXCLUDED_CAPABILITIES_PROPERTY
+            ExaError:new("F-VSCL-PROP-1", "Invalid character(s) in " .. EXCLUDED_CAPABILITIES_PROPERTY
                     .. " property: {{value}}", {value = value})
                     :add_mitigations("Use only the following characters: ASCII letter, digit, underscore, comma, space")
                     :raise()

--- a/src/exasolvs/RequestDispatcher.lua
+++ b/src/exasolvs/RequestDispatcher.lua
@@ -1,6 +1,6 @@
 local log = require("remotelog")
 local cjson = require("cjson")
-local exaerror = require("exaerror")
+local ExaError = require("ExaError")
 
 --- This class dispatches Virtual Schema requests to a Virtual Schema adapter.
 -- It is independent of the use case of the VS adapter and offers functionality that each Virtual Schema needs, like
@@ -47,7 +47,7 @@ function RequestDispatcher:_handle_request(request, properties)
     if(handler ~= nil) then
         return handler(self._adapter, request, properties)
     else
-        exaerror.create("F-RQD-1", "Unknown Virtual Schema request type {{request_type}} received.",
+        ExaError:new("F-RQD-1", "Unknown Virtual Schema request type {{request_type}} received.",
             {request_type = request.type})
             :add_ticket_mitigation()
             :raise(0)

--- a/src/exasolvs/queryrenderer/AbstractQueryAppender.lua
+++ b/src/exasolvs/queryrenderer/AbstractQueryAppender.lua
@@ -1,4 +1,4 @@
-local exaerror = require("exaerror")
+local ExaError = require("ExaError")
 
 --- This class is the abstract base class of all query renderers.
 -- It takes care of handling the temporary storage of the query to be constructed.
@@ -118,9 +118,9 @@ function AbstractQueryAppender:_append_data_type(data_type)
     elseif type == "DOUBLE" or type == "DATE" or type == "BOOLEAN" then
         return
     else
-        exaerror.create("E-VSCL-4", "Unable to render unknown data type {{type}}.",
+        ExaError:new("E-VSCL-4", "Unable to render unknown data type {{type}}.",
                 {type = {value = type, description = "data type that was not recognized"}}
-        ):add_ticket_mitigation():raise()
+        )       :add_ticket_mitigation():raise()
     end
 end
 

--- a/src/exasolvs/queryrenderer/AbstractQueryAppender.lua
+++ b/src/exasolvs/queryrenderer/AbstractQueryAppender.lua
@@ -120,7 +120,7 @@ function AbstractQueryAppender:_append_data_type(data_type)
     else
         ExaError:new("E-VSCL-4", "Unable to render unknown data type {{type}}.",
                 {type = {value = type, description = "data type that was not recognized"}}
-        )       :add_ticket_mitigation():raise()
+        ):add_ticket_mitigation():raise()
     end
 end
 

--- a/src/exasolvs/queryrenderer/ExpressionAppender.lua
+++ b/src/exasolvs/queryrenderer/ExpressionAppender.lua
@@ -1,6 +1,6 @@
 local AbstractQueryAppender = require("exasolvs.queryrenderer.AbstractQueryAppender")
 local text = require("text")
-local exaerror = require("exaerror")
+local ExaError = require("ExaError")
 
 --- Appender for value expressions in a SQL query.
 -- @classmod ExpressionAppender
@@ -18,7 +18,7 @@ local function get_predicate_operator(predicate_type)
     if operator ~= nil then
         return operator
     else
-        exaerror.create("E-VSCL-7", "Cannot determine operator for unknown predicate type {{type}}.",
+        ExaError:new("E-VSCL-7", "Cannot determine operator for unknown predicate type {{type}}.",
                 {type = {value = predicate_type, description = "predicate type that was not recognized"}}
         ):add_ticket_mitigation():raise()
     end
@@ -112,7 +112,7 @@ function ExpressionAppender:append_predicate(predicate)
     elseif type == "exists" then
         self:_append_exists(predicate)
     else
-        exaerror.create("E-VSCL-2", "Unable to render unknown SQL predicate type {{type}}.",
+        ExaError:new("E-VSCL-2", "Unable to render unknown SQL predicate type {{type}}.",
                 {type = {value = predicate.type, description = "predicate type that was not recognized"}}
         ):add_ticket_mitigation():raise()
     end
@@ -155,7 +155,7 @@ function ExpressionAppender:append_expression(expression)
     elseif type == "sub_select" then
         require("exasolvs.queryrenderer.SelectAppender"):new(self._out_query):append_sub_select(expression)
     else
-        exaerror.create("E-VSCL-1", "Unable to render unknown SQL expression type {{type}}.",
+        ExaError:new("E-VSCL-1", "Unable to render unknown SQL expression type {{type}}.",
             {type = {value = expression.type, description = "expression type provided"}}
         ):add_ticket_mitigation():raise()
     end

--- a/src/exasolvs/queryrenderer/ScalarFunctionAppender.lua
+++ b/src/exasolvs/queryrenderer/ScalarFunctionAppender.lua
@@ -1,6 +1,6 @@
 local ExpressionAppender = require("exasolvs.queryrenderer.ExpressionAppender")
 local AbstractQueryAppender = require("exasolvs.queryrenderer.AbstractQueryAppender")
-local exaerror = require("exaerror")
+local ExaError = require("ExaError")
 
 --- Appender for scalar functions in an SQL statement.
 -- @classmod ScalarFunctionAppender
@@ -30,7 +30,7 @@ function ScalarFunctionAppender:append_scalar_function(scalar_function)
     if implementation ~= nil then
         implementation(self, scalar_function)
     else
-        exaerror.create("E-VSCL-3", "Unable to render unsupported scalar function type {{function_name}}.",
+        ExaError:new("E-VSCL-3", "Unable to render unsupported scalar function type {{function_name}}.",
                 {function_name =
                     {value = function_name, description = "name of the SQL function that is not yet supported"}
                 }

--- a/src/exasolvs/queryrenderer/SelectAppender.lua
+++ b/src/exasolvs/queryrenderer/SelectAppender.lua
@@ -1,5 +1,5 @@
 local text = require("text")
-local exaerror = require("exaerror")
+local ExaError = require("ExaError")
 local AbstractQueryRenderer = require("exasolvs.queryrenderer.AbstractQueryAppender")
 
 --- Appender that can add top-level elements of a `SELECT` statement (or sub-select).
@@ -67,7 +67,7 @@ function SelectAppender:_append_join(join)
         self:_append(' ON ')
         self:_append_expression(join.condition)
     else
-        exaerror.create("E-VSCL-6", "Unable to render unknown join type {{type}}.",
+        ExaError:new("E-VSCL-6", "Unable to render unknown join type {{type}}.",
                 {type = {value = join.join_type, description = "type of join that was not recognized"}}
         ):add_ticket_mitigation():raise()
     end
@@ -82,7 +82,7 @@ function SelectAppender:_append_from(from)
         elseif type == "join" then
             self:_append_join(from)
         else
-            exaerror.create("E-VSCL-5", "Unable to render unknown SQL FROM clause type {{type}}.",
+            ExaError:new("E-VSCL-5", "Unable to render unknown SQL FROM clause type {{type}}.",
                     {type = {value = type, description = "type of the FROM clause that was not recognized"}}
             ):add_ticket_mitigation():raise()
         end

--- a/virtual-schema-common-lua-2.0.1-1.rockspec
+++ b/virtual-schema-common-lua-2.0.1-1.rockspec
@@ -1,6 +1,6 @@
 rockspec_format = "3.0"
 
-local tag = "2.0.0"
+local tag = "2.0.1"
 
 package = "virtual-schema-common-lua"
 version = tag .. "-1"
@@ -22,7 +22,7 @@ description = {
 
 dependencies = {
     "lua >= 5.4, < 5.5",
-    "exaerror >= 1.2.2",
+    "exaerror >= 2.0.0",
     "lua-cjson = 2.1.0", -- pinned to prevent "undefined symbol: lua_objlen" in 2.1.0.6 (https://github.com/mpx/lua-cjson/issues/56)
     "remotelog >= 1.1.1"
 }


### PR DESCRIPTION
ExaError had a breaking change in the interface, so this update is a little bit more extensive then expected.

Closes #40.